### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,7 +6,7 @@
         "context": ".",
     },
 
-    "settings": { 
+    "settings": {
         "python.pythonPath": "/usr/local/bin/python",
         "python.languageServer": "Pylance",
         "python.linting.enabled": true,
@@ -28,6 +28,8 @@
     ],
 
     "forwardPorts": [8000],
+
+    "postCreateCommand": "pip install pre-commit && pre-commit install --install-hooks",
 
     "postAttachCommand": "mkdocs serve --dev-addr=0.0.0.0:8000",
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint and style checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,9 @@
+# includes/excludes all rules by default
+default: true
+
+# 4-space list indentation works best with MkDocs
+MD007:
+  indent: 4
+
+# Remove line length limit - no one wants to hard wrap all their paragraphs
+MD013: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.27.1
+    hooks:
+      - id: markdownlint

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,9 @@
+// config file for markdown-link-check
+// see: https://github.com/tcort/markdown-link-check
+{
+    "ignorePatterns": [
+        {
+            "pattern": "localhost"
+        }
+    ]
+}


### PR DESCRIPTION
* Basic file size, line ending, whitespace hooks from [`pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks)
* Markdown linting hook from [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli)
* GitHub Action runs `pre-commit` hooks as well as [`github-action-markdown-link-check`](https://github.com/gaurav-nelson/github-action-markdown-link-check)