### PR TITLE
fix: remove mdx_truly_sane_lists

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 fontawesome_markdown
-mdx_truly_sane_lists
 mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-macros-plugin


### PR DESCRIPTION
This plugin [screws up lists with nested content](https://github.com/radude/mdx_truly_sane_lists/issues/6), we used it in an earlier version of our mkdocs templates. The `mkdocs.yml` in this repo already removes activation of this plugin and the 4-space list indent markdown lint override replaces this plugin trying to make 2-space list indent work