### PR TITLE
Enable light/dark mode toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,8 +8,20 @@ theme:
   features:
     - navigation.tabs
   palette:
-    primary: "blue"
-    accent: "amber"
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: amber
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: amber
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
 
 plugins:
   - search


### PR DESCRIPTION
A media query selects the initial preferred mode from system settings.

See: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle